### PR TITLE
Fix boc debit adapter build errors

### DIFF
--- a/src/adapters/boc-debit/index.ts
+++ b/src/adapters/boc-debit/index.ts
@@ -133,8 +133,13 @@ const extractInfoFromPage = async (page: pdfjs.PDFPageProxy, { cardIdItem, heade
 const convertFromPdf = (file: File): Promise<string> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = async (e) => {
-      const typedArray = new Uint8Array(event?.target?.result as ArrayBuffer);
+    reader.onload = async (event: ProgressEvent<FileReader>) => {
+      const arrayBuffer = event.target?.result;
+      if (!(arrayBuffer instanceof ArrayBuffer)) {
+        reject(new Error('读取文件失败'));
+        return;
+      }
+      const typedArray = new Uint8Array(arrayBuffer);
       try {
         // 加载 PDF 文件
         console.log("try to load pdf")

--- a/tests/adapters/boc-debit/index.test.tsx
+++ b/tests/adapters/boc-debit/index.test.tsx
@@ -1,6 +1,4 @@
 import { vi, beforeEach, test, describe, expect } from 'vitest';
-import fs from 'fs'
-
 import { BocDebitAdapter } from '../../../src/adapters/boc-debit';
 
 import p1TextItems from './p1.json';


### PR DESCRIPTION
Vercel build log:
```
00:32:17.587 Running "pnpm run build"
00:32:17.987 
00:32:17.988 > bill-parser@0.1.0 build /vercel/path0
00:32:17.988 > tsc -b && vite build
00:32:17.988 
00:32:22.138 src/adapters/boc-debit/index.ts(136,28): error TS6133: 'e' is declared but its value is never read.
00:32:22.139 src/adapters/boc-debit/index.ts(137,56): error TS2339: Property 'result' does not exist on type 'EventTarget'.
00:32:22.139 tests/adapters/boc-debit/index.test.tsx(2,1): error TS6133: 'fs' is declared but its value is never read.
00:32:22.139 tests/adapters/boc-debit/index.test.tsx(2,16): error TS2307: Cannot find module 'fs' or its corresponding type declarations.
00:32:22.426  ELIFECYCLE  Command failed with exit code 2.
00:32:22.440 Error: Command "pnpm run build" exited with 2 
```

cc @zwyyy456 