### PR TITLE
fix(abc-debit): normalize text comparison for header matching

### DIFF
--- a/src/adapters/abc-debit/index.tsx
+++ b/src/adapters/abc-debit/index.tsx
@@ -19,9 +19,9 @@ const extractInfoFromPage = async (page: pdfjs.PDFPageProxy) => {
   console.log('allItems', allItems);
 
   const headerItems = AllHeaders
-    .map((header) => allItems.find((item) => item.str === header))
+    .map((header) => allItems.find((item) => item.str.normalize('NFKC') === header.normalize('NFKC')))
     .filter((item): item is TextItem => Boolean(item));
-  const headerDateItem = headerItems.find((item) => item.str === AllHeaders[0]);
+  const headerDateItem = headerItems.find((item) => item.str.normalize('NFKC') === AllHeaders[0].normalize('NFKC'));
   
   const headerXRanges = headerItems.map((item, index) => {
     return {


### PR DESCRIPTION
Use NFKC normalization when comparing text items with headers to ensure proper matching of Unicode characters

Use case:
```
> temp1[6].str
< '交易日期'

> const AllHeaders = ["交易⽇期", "交易时间", "交易摘要", "交易⾦额", "本次余额", "对⼿信息", "⽇ 志 号", "交易渠道", "交易附⾔"];
< undefined

> AllHeaders[0]
< '交易⽇期'

> temp1[6].str === AllHeaders[0]
< false

> temp1[6].str.normalize('NFKC') === AllHeaders[0].normalize('NFKC')
< true
```